### PR TITLE
Remove upper bounds on gem dependencies in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
+      byebug (>= 11.0)
+      pry (>= 0.13)
 
 GEM
   remote: https://rubygems.org/

--- a/pry-byebug.gemspec
+++ b/pry-byebug.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |gem|
   # Dependencies
   gem.required_ruby_version = ">= 2.7.0"
 
-  gem.add_runtime_dependency "byebug", "~> 11.0"
-  gem.add_runtime_dependency "pry", ">= 0.13", "< 0.15"
+  gem.add_runtime_dependency "byebug", ">= 11.0"
+  gem.add_runtime_dependency "pry", ">= 0.13"
 end


### PR DESCRIPTION
This will allow us to use pry 0.15.x, which includes a fix ( https://github.com/pry/pry/issues/ 2328 ) for a warning about `ostruct` in the latest Ruby version. The official gem has a PR open ( https://github.com/deivid-rodriguez/pry-byebug/pull/ 428 ) with a similar change, but that official repo and gem haven't been updated in 3 years, and that particular PR has been unmerged for 2 months now. Therefore, I am taking matters into my own hands, for now. Hopefully the PR will be merged, and I can go back to the official gem via RubyGems.