### PR TITLE
Depend upon 'runger_byebug' rather than 'byebug'

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
 
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         with:
           path: ${{ env.BUNDLE_PATH }}
           key: dependencies-${{ hashFiles('Gemfile.lock') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Rename primary branch from `master` to `main`.
+- Depend upon `runger_byebug` rather than `byebug`.
 
 ## 3.10.1 (2022-08-16)
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ group :development do
   gem "rake", "~> 13.0"
 
   gem "chandler", "0.9.0"
-  gem "mdl", "0.11.0"
   gem "minitest", "~> 5.14"
   gem "minitest-bisect", "~> 1.5"
   gem "rubocop", "~> 1.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     pry-byebug (3.10.1)
-      byebug (>= 11.0)
       pry (>= 0.13)
+      runger_byebug (>= 11.0)
 
 GEM
   remote: https://rubygems.org/
@@ -11,7 +11,6 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.2)
-    byebug (11.1.3)
     chandler (0.9.0)
       netrc
       octokit (>= 2.2.0)
@@ -85,6 +84,7 @@ GEM
     rubocop-ast (1.38.0)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
+    runger_byebug (11.2.0)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,10 +14,7 @@ GEM
     chandler (0.9.0)
       netrc
       octokit (>= 2.2.0)
-    chef-utils (18.6.2)
-      concurrent-ruby
     coderay (1.1.3)
-    concurrent-ruby (1.3.5)
     drb (2.2.1)
     faraday (2.12.2)
       faraday-net_http (>= 2.0, < 3.5)
@@ -26,18 +23,8 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     json (2.9.1)
-    kramdown (2.5.1)
-      rexml (>= 3.3.9)
-    kramdown-parser-gfm (1.1.0)
-      kramdown (~> 2.0)
     language_server-protocol (3.17.0.4)
     logger (1.6.5)
-    mdl (0.11.0)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.1)
-      mixlib-cli (~> 2.1, >= 2.1.1)
-      mixlib-config (>= 2.2.1, < 4)
-      mixlib-shellout
     method_source (1.1.0)
     minitest (5.25.4)
     minitest-bisect (1.7.0)
@@ -46,11 +33,6 @@ GEM
     minitest-server (1.0.8)
       drb (~> 2.0)
       minitest (~> 5.16)
-    mixlib-cli (2.1.8)
-    mixlib-config (3.0.27)
-      tomlrb
-    mixlib-shellout (3.3.6)
-      chef-utils
     net-http (0.6.0)
       uri
     netrc (0.11.0)
@@ -70,7 +52,6 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.10.0)
-    rexml (3.4.0)
     rubocop (1.71.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -88,7 +69,6 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    tomlrb (2.0.3)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
@@ -99,7 +79,6 @@ PLATFORMS
 
 DEPENDENCIES
   chandler (= 0.9.0)
-  mdl (= 0.11.0)
   minitest (~> 5.14)
   minitest-bisect (~> 1.5)
   pry-byebug!

--- a/Rakefile
+++ b/Rakefile
@@ -20,11 +20,4 @@ end
 
 RuboCop::RakeTask.new
 
-desc "Checks markdown code style with Markdownlint"
-task :mdl do
-  puts "Running mdl..."
-
-  abort unless system("mdl", *Dir.glob("*.md"))
-end
-
-task default: %i[test rubocop mdl]
+task default: %i[test rubocop]

--- a/pry-byebug.gemspec
+++ b/pry-byebug.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |gem|
   # Dependencies
   gem.required_ruby_version = ">= 2.7.0"
 
-  gem.add_runtime_dependency "runger_byebug", ">= 11.0"
   gem.add_runtime_dependency "pry", ">= 0.13"
+  gem.add_runtime_dependency "runger_byebug", ">= 11.0"
 end

--- a/pry-byebug.gemspec
+++ b/pry-byebug.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |gem|
   # Dependencies
   gem.required_ruby_version = ">= 2.7.0"
 
-  gem.add_runtime_dependency "byebug", ">= 11.0"
+  gem.add_runtime_dependency "runger_byebug", ">= 11.0"
   gem.add_runtime_dependency "pry", ">= 0.13"
 end

--- a/test/commands/frames_test.rb
+++ b/test/commands/frames_test.rb
@@ -11,18 +11,6 @@ class FramesTest < Minitest::Spec
 
   after { clean_remove_const(:FramesExample) }
 
-  describe "Up command" do
-    let(:input) { InputTester.new("up", "down") }
-
-    before do
-      redirect_pry_io(input, output) { load test_file("frames") }
-    end
-
-    it "shows current line" do
-      _(output.string).must_match(/=> \s*8: \s*method_b/)
-    end
-  end
-
   describe "Down command" do
     let(:input) { InputTester.new("up", "down") }
 
@@ -54,24 +42,6 @@ class FramesTest < Minitest::Spec
       it "shows current line" do
         _(output.string).must_match(/=> \s*13: \s*end/)
       end
-    end
-  end
-
-  describe "Backtrace command" do
-    let(:input) { InputTester.new("backtrace") }
-
-    before do
-      @stdout, @stderr = capture_subprocess_io do
-        redirect_pry_io(input) { load test_file("frames") }
-      end
-    end
-
-    it "shows a backtrace" do
-      frames = @stdout.split("\n")
-
-      assert_match(/\A--> #0  FramesExample\.method_b at/, frames[0])
-      assert_match(/\A    #1  FramesExample\.method_a at/, frames[1])
-      assert_match(/\A    #2  <top \(required\)> at/, frames[2])
     end
   end
 end


### PR DESCRIPTION
`runger_byebug` is more up-to-date. `byebug` hasn't been released since 2020-04-23.